### PR TITLE
fix(#198): Filter out articles that have a timestamp in the future (relative to the request date)

### DIFF
--- a/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/mongodb/DevFeedMongoDbDao.kt
+++ b/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/mongodb/DevFeedMongoDbDao.kt
@@ -290,7 +290,14 @@ class DevFeedMongoDbDao(private val connectionString: String) : DevFeedDao {
   }
 
   override fun getRecentArticles(limit: Int?, offset: Long?): Collection<Article> {
-    val articlesByTimestampDesc = getArticles(limit, offset).sortedByDescending { it.timestamp }
+    val currentTimestamp = System.currentTimeMillis()
+    val articlesByTimestampDesc =
+        getArticles(limit, offset)
+            .filter {
+              // #198 : Filter out articles that have a timestamp in the future
+              it.timestamp <= currentTimestamp
+            }
+            .sortedByDescending { it.timestamp }
     if (articlesByTimestampDesc.isEmpty()) {
       return listOf()
     }

--- a/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/rdbms/DevFeedRdbmsDao.kt
+++ b/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/rdbms/DevFeedRdbmsDao.kt
@@ -727,10 +727,14 @@ class DevFeedRdbmsDao(
     if (datasource.isClosed) {
       throw java.lang.IllegalStateException("Datasource is closed")
     }
+    val currentTimestamp = System.currentTimeMillis()
     val result = mutableListOf<Article>()
     transaction {
       Articles.slice(Articles.timestamp)
-          .selectAll()
+          .select {
+            // #198 : Filter out articles that have a timestamp in the future
+            Articles.timestamp lessEq currentTimestamp
+          }
           .orderBy(Articles.timestamp, order = SortOrder.DESC)
           .limit(1)
           .withDistinct()


### PR DESCRIPTION
Such articles are still persisted, but will not appear in the 'Latest' section, which is supposed to list the latest articles, up to the current date.

This fixes #198 