### PR TITLE
chore!: Remove 'crawlers.task.fetch-articles' application property

### DIFF
--- a/backend/api/src/main/kotlin/org/rm3l/devfeed/crawlers/DevFeedFetcherService.kt
+++ b/backend/api/src/main/kotlin/org/rm3l/devfeed/crawlers/DevFeedFetcherService.kt
@@ -62,8 +62,6 @@ class DevFeedFetcherService(
   @Qualifier("devFeedExecutorService")
   private lateinit var devFeedExecutorService: ExecutorService
 
-  @Value("\${crawlers.task.fetch-articles}") private lateinit var fetchArtcicles: String
-
   @Value("\${crawlers.task.fetch-articles.max-age-days}")
   private lateinit var articlesMaxAgeDays: String
 
@@ -105,7 +103,7 @@ class DevFeedFetcherService(
   @Synchronized
   fun triggerRemoteWebsiteCrawlingAndScreenshotUpdater() {
     try {
-      if (fetchArtcicles.toBoolean() && !crawlers.isNullOrEmpty()) {
+      if (!crawlers.isNullOrEmpty()) {
         crawlers
             .map { crawler ->
               CompletableFuture.runAsync(

--- a/backend/api/src/main/resources/service.properties
+++ b/backend/api/src/main/resources/service.properties
@@ -81,7 +81,6 @@ pagespeedonline.api.timeoutSeconds=60
 # 0 0 9-17 * * MON-FRI = on the hour nine-to-five weekdays
 # 0 0 0 25 12 ? = every Christmas Day at midnight
 #crawlers.task.cron-expression=0 0 1,13 * * *
-crawlers.task.fetch-articles=true
 crawlers.task.fetch-articles.max-age-days=
 crawlers.task.cron-expression=0 0 * * * *
 crawlers.discoverdev_io.enabled=true


### PR DESCRIPTION
This can actually be determined by looking of the list of crawlers injected at runtime.
If that list is empty, then no article can be fetched.
