### PR TITLE
Instruct Jib to build multi-platform images

### DIFF
--- a/backend/api/build.gradle
+++ b/backend/api/build.gradle
@@ -64,7 +64,17 @@ jib {
         image = "${project.group}/${project.name}"
     }
     from {
-        image = 'openjdk:17-alpine'
+        image = 'gcr.io/distroless/java17-debian12'
+        platforms {
+            platform {
+                architecture = 'amd64'
+                os = 'linux'
+            }
+            platform {
+                architecture = 'arm64'
+                os = 'linux'
+            }
+        }
     }
     container {
         labels = [

--- a/backend/crawlers/discoverdev.io/build.gradle
+++ b/backend/crawlers/discoverdev.io/build.gradle
@@ -54,7 +54,17 @@ jib {
         image = "${project.group}/${project.name}"
     }
     from {
-        image = 'openjdk:17-alpine'
+        image = 'gcr.io/distroless/java17-debian12'
+        platforms {
+            platform {
+                architecture = 'amd64'
+                os = 'linux'
+            }
+            platform {
+                architecture = 'arm64'
+                os = 'linux'
+            }
+        }
     }
     container {
         labels = [

--- a/backend/crawlers/engineeringblogs.xyz/build.gradle
+++ b/backend/crawlers/engineeringblogs.xyz/build.gradle
@@ -53,7 +53,17 @@ jib {
         image = "${project.group}/${project.name}"
     }
     from {
-        image = 'openjdk:17-alpine'
+        image = 'gcr.io/distroless/java17-debian12'
+        platforms {
+            platform {
+                architecture = 'amd64'
+                os = 'linux'
+            }
+            platform {
+                architecture = 'arm64'
+                os = 'linux'
+            }
+        }
     }
     container {
         labels = [

--- a/backend/crawlers/rm3l.org/build.gradle
+++ b/backend/crawlers/rm3l.org/build.gradle
@@ -53,7 +53,17 @@ jib {
         image = "${project.group}/${project.name}"
     }
     from {
-        image = 'openjdk:17-alpine'
+        image = 'gcr.io/distroless/java17-debian12'
+        platforms {
+            platform {
+                architecture = 'amd64'
+                os = 'linux'
+            }
+            platform {
+                architecture = 'arm64'
+                os = 'linux'
+            }
+        }
     }
     container {
         labels = [


### PR DESCRIPTION
This will allow using those images on architectures like `arm64`.

This requires switching to a multi-platform base image, like 'gcr.io/distroless/java17-debian12'.
Surprisingly, 'openjdk:17-alpine' is not multi-platform:
```
$ docker manifest inspect openjdk:17-alpine
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 951,
         "digest": "sha256:a996cdcc040704ec6badaf5fecf1e144c096e00231a29188596c784bcf858d05",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      }
   ]
}
```
