### PR TITLE
Make tags case-insensitive and always display lowercase

### DIFF
--- a/backend/common/src/main/kotlin/org/rm3l/devfeed/common/utils/Strings.ext.kt
+++ b/backend/common/src/main/kotlin/org/rm3l/devfeed/common/utils/Strings.ext.kt
@@ -33,3 +33,15 @@ fun String?.asSupportedTimestamp() =
           LocalDateTime.parse("${it}T12:00:00", DateTimeFormatter.ISO_DATE_TIME)
               .toEpochSecond(ZoneOffset.UTC)
     }
+
+/**
+ * Normalizes a tag by lowercasing it, trimming whitespace, replacing internal whitespace with
+ * dashes, and ensuring it is prefixed with `#`.
+ */
+fun String.normalizeTag(): String =
+    this.lowercase().trim().replace("\\s".toRegex(), "-").let {
+      if (it.startsWith("#")) it else "#$it"
+    }
+
+fun Collection<String?>?.normalizeTags(): Set<String> =
+    this?.filterNotNull()?.map { it.normalizeTag() }?.toSet() ?: emptySet()

--- a/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/mongodb/Article.ext.kt
+++ b/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/mongodb/Article.ext.kt
@@ -40,7 +40,12 @@ fun Article.toArticleDocument(): ArticleDocument {
       description = this.description,
       url = this.url,
       domain = this.domain,
-      tags = this.tags?.map { if (it?.startsWith("#") == true) it else "#$it" }?.toSet(),
+      tags =
+          this.tags
+              ?.filterNotNull()
+              ?.map { it.lowercase().trim().replace("\\s".toRegex(), "-") }
+              ?.map { if (it.startsWith("#")) it else "#$it" }
+              ?.toSet(),
       screenshotData = this.screenshot?.data,
       screenshotMimeType = this.screenshot?.mimeType,
       screenshotWidth = this.screenshot?.width,
@@ -80,7 +85,8 @@ fun ArticleFilter?.toBsonFilters(): List<Bson>? {
     mutableFilterList.add(
         Filters.or(
             this.tags!!
-                .map { if (it.startsWith("#") == true) it else "#$it" }
+                .map { it.lowercase().trim().replace("\\s".toRegex(), "-") }
+                .map { if (it.startsWith("#")) it else "#$it" }
                 .map { ArticleDocument::tags contains it }
                 .toList()))
   }

--- a/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/mongodb/Article.ext.kt
+++ b/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/mongodb/Article.ext.kt
@@ -31,6 +31,7 @@ import org.litote.kmongo.eq
 import org.litote.kmongo.regex
 import org.rm3l.devfeed.common.contract.Article
 import org.rm3l.devfeed.common.contract.ArticleFilter
+import org.rm3l.devfeed.common.utils.normalizeTags
 
 fun Article.toArticleDocument(): ArticleDocument {
   return ArticleDocument(
@@ -40,12 +41,7 @@ fun Article.toArticleDocument(): ArticleDocument {
       description = this.description,
       url = this.url,
       domain = this.domain,
-      tags =
-          this.tags
-              ?.filterNotNull()
-              ?.map { it.lowercase().trim().replace("\\s".toRegex(), "-") }
-              ?.map { if (it.startsWith("#")) it else "#$it" }
-              ?.toSet(),
+      tags = this.tags.normalizeTags(),
       screenshotData = this.screenshot?.data,
       screenshotMimeType = this.screenshot?.mimeType,
       screenshotWidth = this.screenshot?.width,
@@ -83,12 +79,7 @@ fun ArticleFilter?.toBsonFilters(): List<Bson>? {
   }
   if (!this.tags.isNullOrEmpty()) {
     mutableFilterList.add(
-        Filters.or(
-            this.tags!!
-                .map { it.lowercase().trim().replace("\\s".toRegex(), "-") }
-                .map { if (it.startsWith("#")) it else "#$it" }
-                .map { ArticleDocument::tags contains it }
-                .toList()))
+        Filters.or(this.tags.normalizeTags().map { ArticleDocument::tags contains it }.toList()))
   }
   if (this.search != null) {
     mutableFilterList.add(

--- a/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/mongodb/DevFeedMongoDbDao.kt
+++ b/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/mongodb/DevFeedMongoDbDao.kt
@@ -38,6 +38,7 @@ import org.rm3l.devfeed.common.contract.ArticleFilter
 import org.rm3l.devfeed.common.contract.ArticleParsed
 import org.rm3l.devfeed.common.contract.Screenshot
 import org.rm3l.devfeed.common.utils.asSupportedTimestamp
+import org.rm3l.devfeed.common.utils.normalizeTag
 import org.rm3l.devfeed.persistence.DevFeedDao
 
 data class ArticleDocument(
@@ -112,6 +113,13 @@ data class ArticleDocument(
 
 data class TagDocument(val tag: String)
 
+/**
+ * Builds a regex matching this string exactly, case-insensitively - so tag lookups remain correct
+ * regardless of the casing under which a tag was originally persisted.
+ */
+private fun String.toCaseInsensitiveExactRegex(): Regex =
+    Regex("^${Regex.escape(this)}$", RegexOption.IGNORE_CASE)
+
 class DevFeedMongoDbDao(private val connectionString: String) : DevFeedDao {
 
   private val mongoClient: MongoClient by lazy { KMongo.createClient(connectionString) }
@@ -147,7 +155,7 @@ class DevFeedMongoDbDao(private val connectionString: String) : DevFeedDao {
   }
 
   override fun existTagByName(name: String): Boolean {
-    return tagCollection.findOne(TagDocument::tag eq name.lowercase()) != null
+    return tagCollection.findOne(TagDocument::tag regex name.toCaseInsensitiveExactRegex()) != null
   }
 
   override fun findArticleById(articleId: String): Article? {
@@ -166,8 +174,7 @@ class DevFeedMongoDbDao(private val connectionString: String) : DevFeedDao {
     val tagDocuments =
         article.tags
             ?.filterNot { it.isNullOrBlank() }
-            ?.map { it!!.lowercase().trim().replace("\\s".toRegex(), "-") }
-            ?.map { if (it.startsWith("#")) it else "#$it" }
+            ?.map { it!!.normalizeTag() }
             ?.filterNot { existTagByName(it) }
             ?.map { TagDocument(tag = it) }
             ?.toList()
@@ -328,7 +335,9 @@ class DevFeedMongoDbDao(private val connectionString: String) : DevFeedDao {
             }
           }
     } else {
-      val filterToBson = Filters.or(search.map { TagDocument::tag eq it.lowercase() }.toList())
+      val filterToBson =
+          Filters.or(
+              search.map { TagDocument::tag regex it.toCaseInsensitiveExactRegex() }.toList())
       findIterable =
           if (limit == null) {
             if (offset == null) {
@@ -350,7 +359,7 @@ class DevFeedMongoDbDao(private val connectionString: String) : DevFeedDao {
           // At least '#<something>'
           it.length >= 2
         }
-        .filter { tag -> search?.any { it.lowercase() == tag } ?: true }
+        .filter { tag -> search?.any { it.equals(tag, ignoreCase = true) } ?: true }
         .toSet()
         .sorted()
   }

--- a/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/mongodb/DevFeedMongoDbDao.kt
+++ b/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/mongodb/DevFeedMongoDbDao.kt
@@ -147,7 +147,7 @@ class DevFeedMongoDbDao(private val connectionString: String) : DevFeedDao {
   }
 
   override fun existTagByName(name: String): Boolean {
-    return tagCollection.findOne(TagDocument::tag eq name) != null
+    return tagCollection.findOne(TagDocument::tag eq name.lowercase()) != null
   }
 
   override fun findArticleById(articleId: String): Article? {
@@ -166,7 +166,7 @@ class DevFeedMongoDbDao(private val connectionString: String) : DevFeedDao {
     val tagDocuments =
         article.tags
             ?.filterNot { it.isNullOrBlank() }
-            ?.map { it!! }
+            ?.map { it!!.lowercase().trim().replace("\\s".toRegex(), "-") }
             ?.map { if (it.startsWith("#")) it else "#$it" }
             ?.filterNot { existTagByName(it) }
             ?.map { TagDocument(tag = it) }
@@ -328,7 +328,7 @@ class DevFeedMongoDbDao(private val connectionString: String) : DevFeedDao {
             }
           }
     } else {
-      val filterToBson = Filters.or(search.map { TagDocument::tag eq it }.toList())
+      val filterToBson = Filters.or(search.map { TagDocument::tag eq it.lowercase() }.toList())
       findIterable =
           if (limit == null) {
             if (offset == null) {
@@ -350,7 +350,7 @@ class DevFeedMongoDbDao(private val connectionString: String) : DevFeedDao {
           // At least '#<something>'
           it.length >= 2
         }
-        .filter { search?.contains(it) ?: true }
+        .filter { tag -> search?.any { it.lowercase() == tag } ?: true }
         .toSet()
         .sorted()
   }

--- a/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/rdbms/DevFeedRdbmsDao.kt
+++ b/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/rdbms/DevFeedRdbmsDao.kt
@@ -41,6 +41,7 @@ import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.lowerCase
 import org.jetbrains.exposed.sql.not
 import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.select
@@ -188,7 +189,9 @@ class DevFeedRdbmsDao(
       throw java.lang.IllegalStateException("Datasource is closed")
     }
     var result = false
-    transaction { result = !Tags.select { Tags.name.eq(name) }.empty() }
+    transaction {
+      result = !Tags.select { Tags.name.lowerCase() eq name.lowercase() }.empty()
+    }
     return result
   }
 
@@ -818,7 +821,7 @@ class DevFeedRdbmsDao(
           if (search != null && search.isNotEmpty()) {
             var searchOp: Op<Boolean> = Op.TRUE
             for (tag in search) {
-              searchOp = searchOp.or(Tags.name.like("%$tag%"))
+              searchOp = searchOp.or(Tags.name.lowerCase() like "%${tag.lowercase()}%")
             }
             tagNameSlice.select { searchOp }
           } else {

--- a/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/rdbms/DevFeedRdbmsDao.kt
+++ b/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/rdbms/DevFeedRdbmsDao.kt
@@ -189,9 +189,7 @@ class DevFeedRdbmsDao(
       throw java.lang.IllegalStateException("Datasource is closed")
     }
     var result = false
-    transaction {
-      result = !Tags.select { Tags.name.lowerCase() eq name.lowercase() }.empty()
-    }
+    transaction { result = !Tags.select { Tags.name.lowerCase() eq name.lowercase() }.empty() }
     return result
   }
 

--- a/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/rdbms/DevFeedRdbmsDao.kt
+++ b/backend/persistence/src/main/kotlin/org/rm3l/devfeed/persistence/impl/rdbms/DevFeedRdbmsDao.kt
@@ -54,6 +54,7 @@ import org.rm3l.devfeed.common.contract.ArticleFilter
 import org.rm3l.devfeed.common.contract.ArticleParsed
 import org.rm3l.devfeed.common.contract.Screenshot
 import org.rm3l.devfeed.common.utils.asSupportedTimestamp
+import org.rm3l.devfeed.common.utils.normalizeTag
 import org.rm3l.devfeed.persistence.DevFeedDao
 import org.slf4j.LoggerFactory
 
@@ -361,8 +362,7 @@ class DevFeedRdbmsDao(
 
       article.tags
           ?.filterNotNull()
-          ?.map { articleTag -> articleTag.lowercase().trim().replace("\\s".toRegex(), "-") }
-          ?.map { articleTag -> if (articleTag.startsWith("#")) articleTag else "#$articleTag" }
+          ?.map { it.normalizeTag() }
           ?.map { articleTag ->
             if (!existTagByName(articleTag)) {
               Tags.insert { it[name] = articleTag }

--- a/mobile/lib/api/articles.dart
+++ b/mobile/lib/api/articles.dart
@@ -83,7 +83,7 @@ class Article {
   static List<String> convertTags(List<dynamic> tags) {
     final result = <String>[];
     for (var tag in tags) {
-      result.add(tag.toString());
+      result.add(tag.toString().toLowerCase());
     }
     return result;
   }

--- a/mobile/lib/api/tags.dart
+++ b/mobile/lib/api/tags.dart
@@ -45,7 +45,7 @@ class TagsClient {
     for (var tag in tagsList) {
       if (tag.toString().length >= 2) {
         //At least '#<something>'
-        result.add(tag.toString());
+        result.add(tag.toString().toLowerCase());
       }
     }
     result

--- a/mobile/lib/ui/tag_lookup.dart
+++ b/mobile/lib/ui/tag_lookup.dart
@@ -30,7 +30,7 @@ enum IndicatorType { overscroll, refresh }
 
 class TagLookup extends StatelessWidget {
   final String _tag;
-  TagLookup(this._tag);
+  TagLookup(String tag) : _tag = tag?.toLowerCase();
 
   @override
   Widget build(BuildContext context) {
@@ -45,7 +45,7 @@ class TagLookup extends StatelessWidget {
 
 class _TagLookupHome extends StatefulWidget {
   final String _tag;
-  _TagLookupHome(this._tag);
+  _TagLookupHome(String tag) : _tag = tag?.toLowerCase();
 
   @override
   State<StatefulWidget> createState() => _TagLookupHomeState();


### PR DESCRIPTION
## Summary
- Backend: normalize tag storage/lookups in both the RDBMS and MongoDB DAOs so tag matching (insert, `existTagByName`, `getTags` search, article `tags` filter) is case-insensitive.
- Mobile: lowercase tags at the API-parsing boundary (`TagsClient` and `Article.convertTags`), and lowercase the tag route param in `TagLookup`, so tags are always displayed and queried in lowercase across the app (tag list, article chips, tag lookup screen).

## Test plan
- [x] `flutter test` passes
- [x] `flutter analyze` shows no new issues introduced by this change
- [ ] Backend build/tests (could not run locally — this environment only has JDK 25 installed, which the project's pinned Gradle version does not support; please run CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Normalize tag handling so that storage, lookup, and display of tags are consistently lowercase and case-insensitive across backend and mobile.

Bug Fixes:
- Ensure MongoDB and RDBMS tag existence checks and search filters are case-insensitive to avoid duplicate or missed tags due to casing differences.

Enhancements:
- Normalize tags in MongoDB and RDBMS by lowercasing and slugifying names before storing and filtering, while preserving hash prefixes.
- Lowercase tags on mobile at parsing and navigation boundaries so tag lists, article chips, and tag lookup screens display tags consistently.